### PR TITLE
FEAT: Add Dynamic Type Setting

### DIFF
--- a/gofrec.go
+++ b/gofrec.go
@@ -37,7 +37,7 @@ func (p *Parser) BytesToLines(fileContents []byte) (int, error) {
 
 func (p *Parser) MapIdentifiers() (int, error) {
 	if len(p.RecordTypes) == 0 {
-		return 0, errors.New("No Record Structs to Map")
+		return 0, errors.New("no record structs to map")
 	}
 
 	identifiersMap := make(map[string]reflect.Type)
@@ -63,7 +63,7 @@ func (p *Parser) MapLine(line string) (interface{}, error) {
 
 	pos := 0
 	for i := 0; i < recordType.NumField(); i++ {
-		if _, ok := recordType.Field(i).Tag.Lookup("Ignore"); ok == true {
+		if _, ok := recordType.Field(i).Tag.Lookup("Ignore"); ok {
 			continue
 		}
 
@@ -87,7 +87,7 @@ func (p *Parser)Parse()(int, error){
 	if len(p.RecordTypes) > 0 && len(p.IdentifierMap) == 0 {
 		p.MapIdentifiers()
 	} else {
-		return 0, errors.New("No record types to parse, please supply an array/slice of structs to parse")
+		return 0, errors.New("no record types to parse, please supply an array/slice of structs to parse")
 	}
 
 	totalRecords := 0

--- a/test/gofrec_test.go
+++ b/test/gofrec_test.go
@@ -9,15 +9,20 @@ import (
 )
 
 type T1 struct {
-	Prop1      string `Identifier:"001" Length:"3"`
-	Prop2      string `Length:"8"`
-	Prop3      string `Length:"10"`
+	Prop1 string `Identifier:"001" Length:"3"`
+	Prop2 string `Length:"8"`
+	Prop3 string `Length:"10"`
 }
 
 type T2 struct {
-	ID string `Identifier:"002" Length:"3"`
+	ID   string `Identifier:"002" Length:"3"`
 	Name string `Length:"8"`
-	
+}
+
+type T3 struct {
+	Prop1 string `Identifier:"001" Length:"3"`
+	Prop2 string `Length:"8"`
+	Prop3 int    `Length:"10"`
 }
 
 func TestBytesToLines(t *testing.T) {
@@ -90,8 +95,8 @@ func TestMapLine(t *testing.T) {
 	par.MapIdentifiers()
 	par.BytesToLines([]byte("001BLAHBLAH1234567890\n001FOO BAR 1234567890"))
 	rec, err := par.MapLine(par.Lines[0])
-	
-	if err != nil{
+
+	if err != nil {
 		t.Error(err, rec)
 	}
 
@@ -119,6 +124,15 @@ func TestParse(t *testing.T) {
 	t.Log(len(par.Records))
 }
 
+func TestDynamicType(t *testing.T) {
+	reflectType := reflect.TypeOf(T3{})
+	reflectValue := reflect.New(reflectType)
+
+	for i := 0; i < reflectType.NumField(); i++ {
+		gofrec.DynamicType(reflectType, i, &reflectValue, "123")
+		t.Log(reflectType.Field(i).Type, i)
+	}
+}
 func TestMapper(t *testing.T) {
 	identifiersMap := make(map[string]reflect.Type)
 

--- a/util.go
+++ b/util.go
@@ -1,0 +1,23 @@
+package gofrec
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+)
+
+func DynamicType(t reflect.Type, fieldIndex int, v *reflect.Value, data string) error {
+
+	switch t.Field(fieldIndex).Type.String() {
+	case "string":
+		v.Elem().Field(fieldIndex).SetString(data)
+		return nil
+
+	case "int", "int8", "int16", "int32", "int64":
+		cVal, _ := strconv.Atoi(data)
+		v.Elem().Field(fieldIndex).SetInt(int64(cVal))
+		return nil
+	default:
+		return errors.New("can't convert type")
+	}
+}


### PR DESCRIPTION
Feature only works for string and int but will be expanded to be used for as many primitive types as possible.